### PR TITLE
Fix fsWatcher configuration comparison

### DIFF
--- a/packages/playwright/src/fsWatcher.ts
+++ b/packages/playwright/src/fsWatcher.ts
@@ -33,7 +33,7 @@ export class Watcher {
   }
 
   async update(watchedPaths: string[], ignoredFolders: string[], reportPending: boolean) {
-    if (JSON.stringify([this._watchedPaths, this._ignoredFolders]) === JSON.stringify(watchedPaths, ignoredFolders))
+    if (JSON.stringify([this._watchedPaths, this._ignoredFolders]) === JSON.stringify([watchedPaths, ignoredFolders]))
       return;
 
     if (reportPending)


### PR DESCRIPTION
## Summary
- correct argument usage in fsWatcher update check

## Testing
- `npm test` *(fails: `playwright` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854ffbfca7c832aae530e1cf1008f57