### PR TITLE
Fix filter empty check and add unit test

### DIFF
--- a/packages/html-reporter/src/filter.ts
+++ b/packages/html-reporter/src/filter.ts
@@ -29,7 +29,8 @@ export class Filter {
   annotations: FilterToken[] = [];
 
   empty(): boolean {
-    return this.project.length + this.status.length + this.text.length === 0;
+    return this.project.length + this.status.length + this.text.length +
+        this.labels.length + this.annotations.length === 0;
   }
 
   static parse(expression: string): Filter {
@@ -215,7 +216,7 @@ export function filterWithToken(tokens: string[], token: string, append: boolean
   }
 
   // if metaKey or ctrlKey is not pressed, replace existing token with new token
-  let prefix: 's:' | 'p:' | '@';
+  let prefix: string | undefined;
   if (token.startsWith('s:'))
     prefix = 's:';
   if (token.startsWith('p:'))
@@ -223,6 +224,8 @@ export function filterWithToken(tokens: string[], token: string, append: boolean
   if (token.startsWith('@'))
     prefix = '@';
 
+  if (!prefix)
+    prefix = token;
   const newTokens = tokens.filter(t => !t.startsWith(prefix));
   newTokens.push(token);
   return '#?q=' + newTokens.join(' ').trim();

--- a/tests/playwright-test/filter-utils.spec.ts
+++ b/tests/playwright-test/filter-utils.spec.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from './playwright-test-fixtures';
+import { Filter, filterWithToken } from '../../packages/html-reporter/src/filter';
+
+test('Filter.empty considers labels and annotations', () => {
+  expect(Filter.parse('@smoke').empty()).toBe(false);
+  expect(Filter.parse('annot:skip').empty()).toBe(false);
+  expect(Filter.parse('').empty()).toBe(true);
+});
+
+test('filterWithToken handles tokens without known prefixes', () => {
+  expect(filterWithToken([], 'custom', false)).toBe('#?q=custom');
+  expect(filterWithToken(['custom'], 'custom', true)).toBe('#?q=');
+});
+


### PR DESCRIPTION
## Summary
- ensure `Filter.empty()` considers label and annotation tokens
- handle unknown token prefixes in `filterWithToken`
- add tests for filter utility functions

## Testing
- `npm run ttest tests/playwright-test/filter-utils.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_685503ba27d4832a9d1abd1be08b1cbd