### PR TITLE
Fix missing baseURL in mock-battery example

### DIFF
--- a/examples/mock-battery/playwright.config.js
+++ b/examples/mock-battery/playwright.config.js
@@ -8,6 +8,9 @@ module.exports = defineConfig({
     port: 9900,
     command: 'npm run start',
   },
+  use: {
+    baseURL: 'http://localhost:9900',
+  },
   // Test directory
   testDir: path.join(__dirname, 'tests'),
 });

--- a/packages/playwright/src/fsWatcher.ts
+++ b/packages/playwright/src/fsWatcher.ts
@@ -33,7 +33,7 @@ export class Watcher {
   }
 
   async update(watchedPaths: string[], ignoredFolders: string[], reportPending: boolean) {
-    if (JSON.stringify([this._watchedPaths, this._ignoredFolders]) === JSON.stringify(watchedPaths, ignoredFolders))
+    if (JSON.stringify([this._watchedPaths, this._ignoredFolders]) === JSON.stringify([watchedPaths, ignoredFolders]))
       return;
 
     if (reportPending)


### PR DESCRIPTION
## Summary
- set `baseURL` for mock-battery tests so that `page.goto('/')` works
- fix Watcher update check

## Testing
- `npm run build`
- `node -e "const { Watcher } = require('./packages/playwright/lib/fsWatcher.js'); console.log('type:', typeof Watcher);"`


------
https://chatgpt.com/codex/tasks/task_e_685509432c74832a93f3a8e77d385c77